### PR TITLE
pos-print/build: shadow lib dependencies into a fat jar

### DIFF
--- a/pos-print-client/build.gradle
+++ b/pos-print-client/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.0.5-3'
+  ext.kotlin_version = '1.0.6'
   repositories {
     mavenCentral()
   }
@@ -10,7 +10,7 @@ buildscript {
 }
 
 apply plugin: 'java'
-apply plugin: "kotlin"
+apply plugin: 'kotlin'
 
 allprojects {
   apply plugin: 'java'

--- a/pos-print/build.gradle
+++ b/pos-print/build.gradle
@@ -1,16 +1,20 @@
 buildscript {
-  ext.kotlin_version = '1.0.5-3'
+  ext.kotlin_version = '1.0.6'
   repositories {
     mavenCentral()
+    jcenter()
   }
 
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+
   }
 }
 
 apply plugin: 'java'
-apply plugin: "kotlin"
+apply plugin: 'kotlin'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 allprojects {
   apply plugin: 'java'
@@ -22,6 +26,18 @@ repositories {
   mavenCentral()
   mavenLocal()
   maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+}
+
+jar {
+  manifest {
+    attributes 'Main-Class': 'com.clouway.pos.print.PosPrintService'
+  }
+}
+
+shadowJar {
+  baseName = 'pos-print'
+  exclude 'META-INF/*.DSA'
+  exclude 'META-INF/*.RSA'
 }
 
 dependencies {
@@ -58,11 +74,11 @@ dependencies {
   compile('dom4j:dom4j:1.6.1') {
     exclude module: 'xml-apis'
   }
-  
+
   compile 'org.eclipse.jetty:jetty-server:8.1.8.v20121106'
   compile 'org.eclipse.jetty:jetty-servlet:8.1.8.v20121106'
   compile 'javax.servlet:javax.servlet-api:3.1.0'
-  
+
   compile 'org.slf4j:slf4j-api:1.6.3'
   compile 'ch.qos.logback:logback-classic:0.9.30'
 

--- a/pos-print/src/main/java/com/clouway/pos/print/PosPrintService.java
+++ b/pos-print/src/main/java/com/clouway/pos/print/PosPrintService.java
@@ -15,5 +15,15 @@ public class PosPrintService {
     backend.start();
     
     System.out.printf("POS Print Service is up and running on port: %d", httpPort);
+
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      System.out.printf("POS Print Service is going to shutdown.");
+      try {
+        backend.stop();
+      } catch (Exception e) {
+        System.out.println("Failed to stop server due: " + e.getMessage());
+      }
+      System.out.printf("POS Print Service goes down.");
+    }));
   }
 }

--- a/pos-print/src/main/java/com/clouway/pos/print/adapter/http/HttpBackend.java
+++ b/pos-print/src/main/java/com/clouway/pos/print/adapter/http/HttpBackend.java
@@ -53,4 +53,9 @@ public class HttpBackend {
     }
   }
 
+
+  public void stop() throws Exception {
+    server.stop();
+  }
+
 }

--- a/pos-print/src/main/resources/logback.xml
+++ b/pos-print/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</Pattern>
+    </layout>
+  </appender>
+
+  <logger name="com.clouway" level="DEBUG">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+</configuration>


### PR DESCRIPTION
All dependencies are now packaged into the executable jar and app could be distributed easily.

To pack app into executable jar you have to execute:

```sh
gradle clean shadowJar
java -jar build/libs/pos-print-all.jar
```