### PR TITLE
pos-print/fp705: fix few more tests

### DIFF
--- a/pos-print/src/main/java/com/clouway/pos/print/core/RequestTimeoutException.java
+++ b/pos-print/src/main/java/com/clouway/pos/print/core/RequestTimeoutException.java
@@ -1,0 +1,14 @@
+package com.clouway.pos.print.core;
+
+/**
+ * An exceptional class used to indicate errors which are occurring due reaching
+ * the timeout of the operation.
+ * 
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public class RequestTimeoutException extends RuntimeException {
+  
+  public RequestTimeoutException(String message) {
+    super(message);
+  }
+}

--- a/pos-print/src/test/java/com/clouway/pos/print/printer/FakeFP705.kt
+++ b/pos-print/src/test/java/com/clouway/pos/print/printer/FakeFP705.kt
@@ -1,7 +1,6 @@
 package com.clouway.pos.print.printer
 
 import com.google.common.util.concurrent.AbstractExecutionThreadService
-import org.junit.Assert.fail
 import java.io.IOException
 import java.net.ServerSocket
 
@@ -10,7 +9,7 @@ import java.net.ServerSocket
  */
 
 class FakeFP705 : AbstractExecutionThreadService() {
-    internal var s: ServerSocket = ServerSocket(5555)
+    internal var s: ServerSocket = ServerSocket(0)
     internal var flows: ArrayList<Flow> = ArrayList()
 
     fun port(): Int {
@@ -40,9 +39,13 @@ class FakeFP705 : AbstractExecutionThreadService() {
                     val requestedBytes = b.sliceArray(IntRange(0, readBytes - 1))
 
                     if (!requestedBytes.contentEquals(f.request)) {
-                        fail("expected request: " + f.request.toHexString() + "\n , got: " + requestedBytes.toHexString())
                         output.write(0x15)
                         c.close()
+                        throw RuntimeException(
+                                "\n" +
+                                        "expected request: " + f.request.toHexString() + "\n," +
+                                        "            got: " + requestedBytes.toHexString()
+                        )
                         break
                     } else {
                         output.write(f.response)


### PR DESCRIPTION
All tests are now using the Fake implementation of FP705.

Few minor gotchas for timeouts are now addressed, to prevent issues.