### PR TITLE
pos-print: fix for uri naming

### DIFF
--- a/pos-print/src/main/java/com/clouway/pos/print/adapter/http/ReportService.kt
+++ b/pos-print/src/main/java/com/clouway/pos/print/adapter/http/ReportService.kt
@@ -19,7 +19,7 @@ import java.time.format.DateTimeFormatter
  *@author Borislav Gadjev <borislav.gadjev@clouway.com>
  */
 @Service
-@At("/v1/report")
+@At("/v1/reports")
 class ReportService(private var factory: PrinterFactory) {
 
   @Post


### PR DESCRIPTION
Renamed the uri in ReportService from /v1/report to /v1/reports because it was mismatching with the one in HttpModule.