### PR TITLE
pos-print: fix for ReportService logic

### DIFF
--- a/docs/swagger/api.yaml
+++ b/docs/swagger/api.yaml
@@ -205,8 +205,10 @@ definitions:
         example: "1"
       registerState:
         type: string
-        description: the state which the chash register is going to acquire
-        example: CLEAR or KEEP
+        description: The state which the chash register is going to acquire
+        enum:
+          - KEEP
+          - CLEAR
   PeriodReportRequest:
     type: object
     properties:
@@ -214,16 +216,22 @@ definitions:
         type: string
         format: date-time
         description: The starting date for the report
-        example: 2017-04-23T18:25:43.511Z
+        example: 2017-04-23T18:25:43
       to:
         type: string
         format: date-time
         description: The ending date for the report
-        example: 2017-04-23T18:25:43.511Z
+        example: 2017-04-23T18:25:43
       sourceIp:
         type: string
         description: Unique ip representing the owner of the device.
         example: 89.100.10.5
+      periodType:
+        type: string
+        description: The type for the period report
+        enum:
+          - SHORT
+          - EXTENDED
   Error:
     type: object
     properties:

--- a/pos-print/src/main/java/com/clouway/pos/print/adapter/http/ReportService.kt
+++ b/pos-print/src/main/java/com/clouway/pos/print/adapter/http/ReportService.kt
@@ -1,10 +1,8 @@
 package com.clouway.pos.print.adapter.http
 
-import com.clouway.pos.print.core.DeviceNotFoundException
-import com.clouway.pos.print.core.ErrorResponse
-import com.clouway.pos.print.core.PrinterFactory
-import com.clouway.pos.print.core.RegisterState
+import com.clouway.pos.print.core.*
 import com.clouway.pos.print.transport.GsonTransport
+import com.google.inject.Inject
 import com.google.sitebricks.At
 import com.google.sitebricks.client.transport.Json
 import com.google.sitebricks.headless.Reply
@@ -12,30 +10,30 @@ import com.google.sitebricks.headless.Request
 import com.google.sitebricks.headless.Service
 import com.google.sitebricks.http.Post
 import java.io.IOException
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
+import java.time.LocalDateTime
 
 /**
  *@author Borislav Gadjev <borislav.gadjev@clouway.com>
  */
 @Service
 @At("/v1/reports")
-class ReportService(private var factory: PrinterFactory) {
+class ReportService @Inject constructor(private var factory: PrinterFactory) {
 
   @Post
   @At("/operator/print")
   fun printOperatorReport(request: Request): Reply<*> {
     try {
       val operatorReportDTO = request.read(OperatorReportDTO::class.java).`as`(GsonTransport::class.java)
+
       val printer = factory.getPrinter(operatorReportDTO.sourceIp)
 
-      printer.reportForOperator(operatorReportDTO.operatorId, adapt(operatorReportDTO.registerState))
+      printer.reportForOperator(operatorReportDTO.operatorId, adaptToState(operatorReportDTO.registerState))
       printer.close()
 
     } catch (e: DeviceNotFoundException) {
-      return Reply.with(ErrorResponse("Device not found.")).badRequest()
+      return Reply.with(ErrorResponse("Device not found.")).`as`(GsonTransport::class.java).badRequest()
     } catch (e: IOException) {
-      return Reply.with(ErrorResponse("Device can't connect.")).status(480)
+      return Reply.with(ErrorResponse("Device can't connect.")).`as`(GsonTransport::class.java).status(480)
     }
     return Reply.with("Report completed").`as`(Json::class.java).ok()
   }
@@ -45,30 +43,34 @@ class ReportService(private var factory: PrinterFactory) {
   fun printPeriodReport(request: Request): Reply<*> {
     try {
       val periodReportDTO = request.read(PeriodReportDTO::class.java).`as`(GsonTransport::class.java)
+
       val printer = factory.getPrinter(periodReportDTO.sourceIp)
 
-      printer.reportForPeriod(adaptToDate(periodReportDTO.from), adaptToDate(periodReportDTO.to))
+      printer.reportForPeriod(periodReportDTO.from, periodReportDTO.to, adaptToType(periodReportDTO.periodType))
       printer.close()
 
     } catch (e: DeviceNotFoundException) {
-      return Reply.with(ErrorResponse("Device not found.")).badRequest()
+      return Reply.with(ErrorResponse("Device not found.")).`as`(GsonTransport::class.java).badRequest()
     } catch (e: IOException) {
-      return Reply.with(ErrorResponse("Device can't connect.")).status(480)
+      return Reply.with(ErrorResponse("Device can't connect.")).`as`(GsonTransport::class.java).status(480)
     }
     return Reply.with("Report completed").`as`(Json::class.java).ok()
   }
 
-  private fun adapt(state: String): RegisterState {
+  private fun adaptToState(state: String): RegisterState {
     if (state.equals("CLEAR")) {
       return RegisterState.CLEAR
     }
     return RegisterState.KEEP
   }
 
-  private fun adaptToDate(date: String): LocalDate {
-    return LocalDate.parse(date, DateTimeFormatter.ISO_DATE_TIME)
+  private fun adaptToType(type: String): PeriodType {
+    if (type.equals("SHORT")) {
+      return PeriodType.SHORT
+    }
+    return PeriodType.EXTENDED
   }
 
   internal data class OperatorReportDTO(var registerState: String = "", var operatorId: String = "", var sourceIp: String = "")
-  internal data class PeriodReportDTO(var from: String = "", var to: String = "", var sourceIp: String = "")
+  internal data class PeriodReportDTO(var from: LocalDateTime = LocalDateTime.now(), var to: LocalDateTime = LocalDateTime.now(), var sourceIp: String = "", var periodType: String = "")
 }

--- a/pos-print/src/main/java/com/clouway/pos/print/core/CoreModule.kt
+++ b/pos-print/src/main/java/com/clouway/pos/print/core/CoreModule.kt
@@ -1,6 +1,5 @@
 package com.clouway.pos.print.core
 
-import com.clouway.pos.print.printer.FP705Printer
 import com.clouway.pos.print.printer.FP705PrinterFactory
 import com.google.inject.AbstractModule
 

--- a/pos-print/src/main/java/com/clouway/pos/print/core/PeriodType.kt
+++ b/pos-print/src/main/java/com/clouway/pos/print/core/PeriodType.kt
@@ -1,0 +1,11 @@
+package com.clouway.pos.print.core
+
+/**
+ *@author Borislav Gadjev <borislav.gadjev@clouway.com>
+ */
+enum class PeriodType {
+  /* Short report type */
+  SHORT,
+  /* Extended report type */
+  EXTENDED
+}

--- a/pos-print/src/main/java/com/clouway/pos/print/core/ReceiptPrinter.java
+++ b/pos-print/src/main/java/com/clouway/pos/print/core/ReceiptPrinter.java
@@ -1,7 +1,7 @@
 package com.clouway.pos.print.core;
 
 import java.io.IOException;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
@@ -40,9 +40,10 @@ public interface ReceiptPrinter {
    *
    * @param start the starting date for the report
    * @param end   the ending date for the report
+   * @param periodType the type of period - SHORT or EXTENDED
    * @throws IOException is thrown in case of IO error
    */
-  void reportForPeriod(LocalDate start, LocalDate end) throws IOException;
+  void reportForPeriod(LocalDateTime start, LocalDateTime end, PeriodType periodType) throws IOException;
 
   /**
    * Closes communication with the printer

--- a/pos-print/src/main/java/com/clouway/pos/print/printer/FP705Printer.java
+++ b/pos-print/src/main/java/com/clouway/pos/print/printer/FP705Printer.java
@@ -5,6 +5,7 @@ import com.clouway.pos.print.core.Receipt;
 import com.clouway.pos.print.core.ReceiptItem;
 import com.clouway.pos.print.core.ReceiptPrinter;
 import com.clouway.pos.print.core.RegisterState;
+import com.clouway.pos.print.core.PeriodType;
 import com.clouway.pos.print.core.RequestTimeoutException;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Bytes;
@@ -18,7 +19,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.SocketTimeoutException;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Set;
 
@@ -102,9 +103,8 @@ public class FP705Printer implements ReceiptPrinter {
     printResponse(sendPacket(buildPacket(seq, TEXT_RECEIPT_CLOSE, "")));
   }
 
-
-  public void reportForPeriod(LocalDate start, LocalDate end) throws IOException {
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yy");
+  public void reportForPeriod(LocalDateTime start, LocalDateTime end, PeriodType periodType) throws IOException {
+    DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
     
     // Command: 94 (5Еh) – fiscal memory report by date
     // Parameters of the command: {Type}<SEP>{Start}<SEP>{End}<SEP> Mandatory parameters:
@@ -113,6 +113,10 @@ public class FP705Printer implements ReceiptPrinter {
     //    • End – End date. Default: Current date ( format DD–MM–YY ); Answer: {ErrorCode}<SEP>
     //    • ErrorCode – Indicates an error code. If command passed, ErrorCode is 0;
     String type = "0";
+    if (periodType == PeriodType.EXTENDED) {
+      type = "1";
+    }
+
     String from = start.format(formatter);
     String to = end.format(formatter);
     String data = params(type, from, to);
@@ -131,7 +135,7 @@ public class FP705Printer implements ReceiptPrinter {
    * state after the operation.
    *
    * @param operatorId the id of the operator for which report need to be issued
-   * @param state      the prefferred state after operation completes
+   * @param state      the preferred state after operation completes
    * @throws IOException is thrown in case of IO error
    */
   public void reportForOperator(String operatorId, RegisterState state) throws IOException {

--- a/pos-print/src/main/java/com/clouway/pos/print/transport/GsonTransport.kt
+++ b/pos-print/src/main/java/com/clouway/pos/print/transport/GsonTransport.kt
@@ -31,12 +31,12 @@ constructor() : Transport {
 
     override fun read(reader: JsonReader): LocalDateTime? {
       if (reader.peek() == JsonToken.NULL) {
-        reader.nextNull();
-        return null;
+        reader.nextNull()
+        return null
       }
 
       val value = reader.nextString()
-      return LocalDateTime.from(DateTimeFormatter.ISO_LOCAL_DATE_TIME.parse(value));
+      return LocalDateTime.from(DateTimeFormatter.ISO_LOCAL_DATE_TIME.parse(value))
     }
 
   }

--- a/pos-print/src/test/java/com/clouway/pos/print/adapter/http/ReportServiceTest.kt
+++ b/pos-print/src/test/java/com/clouway/pos/print/adapter/http/ReportServiceTest.kt
@@ -13,7 +13,7 @@ import org.jmock.integration.junit4.JUnitRuleMockery
 import org.junit.Rule
 import org.junit.Test
 import java.io.IOException
-import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 /**
@@ -85,13 +85,13 @@ class ReportServiceTest {
 
   @Test
   fun printReportForPeriod() {
-    val periodReportDTO = ReportService.PeriodReportDTO("2017-04-23T18:25:43.511Z", "2017-04-23T18:25:43.511Z", "::any ip::")
+    val periodReportDTO = ReportService.PeriodReportDTO(LocalDateTime.parse("2017-04-23T18:25:43", DateTimeFormatter.ISO_LOCAL_DATE_TIME), LocalDateTime.parse("2017-04-23T18:25:43", DateTimeFormatter.ISO_LOCAL_DATE_TIME), "::any ip::", "SHORT")
 
     context.checking(object : Expectations() {
       init {
         oneOf(factory).getPrinter("::any ip::")
         will(AbstractExpectations.returnValue(printer))
-        oneOf(printer).reportForPeriod(LocalDate.parse("2017-04-23T18:25:43.511Z", DateTimeFormatter.ISO_DATE_TIME), LocalDate.parse("2017-04-23T18:25:43.511Z", DateTimeFormatter.ISO_DATE_TIME))
+        oneOf(printer).reportForPeriod(LocalDateTime.parse("2017-04-23T18:25:43", DateTimeFormatter.ISO_LOCAL_DATE_TIME), LocalDateTime.parse("2017-04-23T18:25:43", DateTimeFormatter.ISO_LOCAL_DATE_TIME), PeriodType.SHORT)
         oneOf(printer).close()
       }
     })
@@ -104,7 +104,7 @@ class ReportServiceTest {
 
   @Test
   fun missingCashRegisterForPeriodReport() {
-    val periodReportDTO = ReportService.PeriodReportDTO("2017-04-23T18:25:43.511Z", "2017-04-23T18:25:43.511Z", "::any ip::")
+    val periodReportDTO = ReportService.PeriodReportDTO(LocalDateTime.parse("2017-04-23T18:25:43", DateTimeFormatter.ISO_LOCAL_DATE_TIME), LocalDateTime.parse("2017-04-23T18:25:43", DateTimeFormatter.ISO_LOCAL_DATE_TIME), "::any ip::", "EXTENDED")
 
     context.checking(object : Expectations() {
       init {
@@ -121,7 +121,7 @@ class ReportServiceTest {
 
   @Test
   fun connectionFailureForPeriodReport() {
-    val periodReportDTO = ReportService.PeriodReportDTO("2017-04-23T18:25:43.511Z", "2017-04-23T18:25:43.511Z", "::any ip::")
+    val periodReportDTO = ReportService.PeriodReportDTO(LocalDateTime.parse("2017-04-23T18:25:43", DateTimeFormatter.ISO_LOCAL_DATE_TIME), LocalDateTime.parse("2017-04-23T18:25:43", DateTimeFormatter.ISO_LOCAL_DATE_TIME), "::any ip::", "EXTENDED")
 
     context.checking(object : Expectations() {
       init {

--- a/pos-print/src/test/java/com/clouway/pos/print/printer/FP705PrinterTest.java
+++ b/pos-print/src/test/java/com/clouway/pos/print/printer/FP705PrinterTest.java
@@ -2,6 +2,7 @@ package com.clouway.pos.print.printer;
 
 
 import com.clouway.pos.print.core.RegisterState;
+import com.clouway.pos.print.core.PeriodType;
 import com.clouway.pos.print.printer.FakeFP705.Flow;
 import org.junit.After;
 import org.junit.Before;
@@ -10,7 +11,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.Socket;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 
 import static com.clouway.pos.print.core.Receipt.newReceipt;
@@ -310,7 +311,7 @@ public class FP705PrinterTest {
                             0x32, 0x35, 0x03},
                     new byte[]{0x16} //response is not relative
             ));
-    printer().reportForPeriod(LocalDate.of(2017, 4, 1), LocalDate.of(2017, 4, 13));
+    printer().reportForPeriod(LocalDateTime.of(2017, 4, 13, 14, 44, 22, 556), LocalDateTime.of(2017, 4, 13, 14, 44, 22, 556), PeriodType.SHORT);
   }
 
   @Test


### PR DESCRIPTION
Fixed the ReportService logic, now there's enum with values SHORT and EXTENDED that are used for period report.