### PR TITLE
adapter/http: allow passing of timezone which is omitted

### DIFF
--- a/pos-print/src/main/java/com/clouway/pos/print/transport/GsonTransport.kt
+++ b/pos-print/src/main/java/com/clouway/pos/print/transport/GsonTransport.kt
@@ -26,7 +26,7 @@ constructor() : Transport {
         out.nullValue()
         return
       }
-      out.value(value.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+      out.value(value.format(DateTimeFormatter.ISO_DATE_TIME))
     }
 
     override fun read(reader: JsonReader): LocalDateTime? {
@@ -36,7 +36,7 @@ constructor() : Transport {
       }
 
       val value = reader.nextString()
-      return LocalDateTime.from(DateTimeFormatter.ISO_LOCAL_DATE_TIME.parse(value))
+      return LocalDateTime.from(DateTimeFormatter.ISO_DATE_TIME.parse(value))
     }
 
   }

--- a/pos-print/src/test/java/com/clouway/pos/print/adapter/http/JsonSerialziationTest.kt
+++ b/pos-print/src/test/java/com/clouway/pos/print/adapter/http/JsonSerialziationTest.kt
@@ -53,6 +53,28 @@ class JsonSerialziationTest {
     assertThat(request.time?.dayOfMonth, equalTo(4))
   }
 
+  @Test
+  fun timeZoneIsOmitted() {
+    val transport = GsonTransport();
+    val source = "{\"time\":\"2017-03-04T00:00:00+01:00\"}";
+    val request = transport.`in`(ByteArrayInputStream(source.toByteArray()), TestRequest::class.java)
+
+    assertThat(request.time?.year, equalTo(2017))
+    assertThat(request.time?.monthValue, equalTo(3))
+    assertThat(request.time?.dayOfMonth, equalTo(4))
+  }
+
+  @Test
+  fun timeZoneWithNameIsOmitted() {
+    val transport = GsonTransport();
+    val source = "{\"time\":\"2017-03-04T00:00:00+01:00[Europe/Paris]\"}";
+    val request = transport.`in`(ByteArrayInputStream(source.toByteArray()), TestRequest::class.java)
+
+    assertThat(request.time?.year, equalTo(2017))
+    assertThat(request.time?.monthValue, equalTo(3))
+    assertThat(request.time?.dayOfMonth, equalTo(4))
+  }
+
   @Test(expected = DateTimeParseException::class)
   fun deserializeBadFormattedLocalDateTime() {
     val transport = GsonTransport();


### PR DESCRIPTION
The GsonAdapter is now allowing and timezone part to be passed with the message but it's discarded as it's not used and is not required.