### PR TITLE
pos-print: remove un-used ExampleTest

### DIFF
--- a/pos-print/src/test/java/com/clouway/pos/print/ExampleTest.java
+++ b/pos-print/src/test/java/com/clouway/pos/print/ExampleTest.java
@@ -1,7 +1,0 @@
-package com.clouway.pos.print;
-
-/**
- * @author Miroslav Genov (miroslav.genov@clouway.com)
- */
-public class ExampleTest {
-}


### PR DESCRIPTION
The ExampleTest which was used to keep folder structure is now longer required and is now removed.